### PR TITLE
fix incorrect docker image matching

### DIFF
--- a/public/js/editor.bundle.js
+++ b/public/js/editor.bundle.js
@@ -274,6 +274,7 @@ async function updatePreview() {
   src = src.replace(/\?v=\d+/, ``);
   src += `?v=${Date.now()}`;
   newFrame.dataset.src = src;
+  newFrame.dataset.projectName = iframe.dataset.projectName;
   newFrame.dataset.projectSlug = iframe.dataset.projectSlug;
   preview.append(newFrame);
   setTimeout(() => newFrame.src = src, 100);

--- a/public/themes/default/pages/editor.html
+++ b/public/themes/default/pages/editor.html
@@ -112,6 +112,7 @@
           src="https://{{ WEB_EDITOR_HOSTNAME }}/default/index.html"
           data-src="https://{{ project.slug }}.{{ WEB_EDITOR_APPS_HOSTNAME }}"
           data-project-name="{{ project.name }}"
+          data-project-slug="{{ project.slug }}"
         ></iframe>
       </div>
     </main>

--- a/src/client/preview/preview.js
+++ b/src/client/preview/preview.js
@@ -62,6 +62,7 @@ export async function updatePreview() {
   src = src.replace(/\?v=\d+/, ``);
   src += `?v=${Date.now()}`;
   newFrame.dataset.src = src;
+  newFrame.dataset.projectName = iframe.dataset.projectName;
   newFrame.dataset.projectSlug = iframe.dataset.projectSlug;
 
   // console.log(`using ${src}`);

--- a/src/server/caddy/caddy.js
+++ b/src/server/caddy/caddy.js
@@ -85,6 +85,10 @@ process.on("SIGINT", () => {
  */
 export function updateCaddyFile(project, port, env = process.env) {
   const { slug } = project;
+
+  portBindings[slug] ??= {};
+  portBindings[slug].port = port;
+
   const data = readFileSync(caddyFile).toString();
   const host = `${slug}.${env.WEB_EDITOR_APPS_HOSTNAME}`;
   const index = data.indexOf(host);
@@ -116,9 +120,6 @@ ${host} {
 `;
 
     writeFileSync(caddyFile, data + entry);
-
-    portBindings[slug] ??= {};
-    portBindings[slug].port = port;
   }
 
   spawn(`caddy reload --config ${caddyFile}`, {

--- a/src/server/docker/docker-helpers.js
+++ b/src/server/docker/docker-helpers.js
@@ -146,7 +146,8 @@ export async function runContainer(project, slug = project.slug) {
   // Do we have an image?
   console.log(`- Checking for image`);
   let result = execSync(`docker image list`).toString().trim();
-  const foundProject = () => result.match(new RegExp(`^${slug}\\b`, `gm`));
+  const foundProject = () =>
+    result.match(new RegExp(`(^|\\s)${slug}\\b`, `gm`));
 
   // If not, build one.
   if (!foundProject()) {


### PR DESCRIPTION
Hopefully addresses #170 by switching from "start of line" to "start of line or whitespace" boundary matching for project images.