### PR TITLE
Use correct name to fix projects setup query

### DIFF
--- a/src/setup/sqlite.js
+++ b/src/setup/sqlite.js
@@ -55,7 +55,7 @@ export async function setupSqlite() {
         db.prepare(
           `INSERT INTO projects (name, slug, description) VALUES (?, ?, ?)`,
         ).run(starterName, slug, description);
-        result = db.prepare(`SELECT * FROM projects WHERE name = ?`).get(name);
+        result = db.prepare(`SELECT * FROM projects WHERE name = ?`).get(starterName);
         const { id } = result;
         db.prepare(
           `INSERT INTO project_settings (project_id, default_file, default_collapse, run_script, env_vars, app_type, root_dir) VALUES (?,?,?,?,?,?,?)`,


### PR DESCRIPTION
Fixes #180.

Previously, this was using `starterName` in the `name` field when preparing the projects query. As a result, the project would not be found, and it would fail. 

Additionally, after failing, it would have already created the database, meaning that when the script is re-run, `BYPASS_FINISH` would be set to true since the file at the dbPath exists. This results in the initial user not being setup correctly.

By fixing the query, the projects can be found, and the sqlite setup completes correctly and sets `.finish_setup` for use in creation of the first user as admin. (Confirmed working.)