### PR TITLE
Extract notices.css colors to variables

### DIFF
--- a/public/themes/default/css/editor/notices.css
+++ b/public/themes/default/css/editor/notices.css
@@ -17,21 +17,16 @@ body {
 
     &.info {
       background: var(--notice-info-background);
-      color: var(--black);
-      text-shadow: var(--notice-text-shadow-sizing)
-        var(--notice-light-text-shadow);
+      text-shadow: 1px 1px 1px var(--notice-light-text-shadow);
     }
     &.warning {
       background: var(--notice-warning-background);
-      color: var(--black);
-      text-shadow: var(--notice-text-shadow-sizing)
-        var(--notice-light-text-shadow);
+      text-shadow: 1px 1px 1px var(--notice-light-text-shadow);
     }
     &.error {
       background: var(--notice-error-background);
       color: var(--white);
-      text-shadow: var(--notice-text-shadow-sizing)
-        var(--notice-dark-text-shadow);
+      text-shadow: 1px 1px 1px var(--notice-dark-text-shadow);
     }
 
     .close {

--- a/public/themes/default/css/variables.css
+++ b/public/themes/default/css/variables.css
@@ -7,7 +7,6 @@
   --notice-info-background:#99ffaf;
   --notice-warning-background:#fff2aa;
   --notice-error-background: #db3939;
-  --notice-text-shadow-sizing: 1px 1px 1px;
   --notice-light-box-shadow: black;
   --notice-light-text-shadow: #ececec;
   --notice-dark-box-shadow: black;


### PR DESCRIPTION
This contributes to #123 .

Just a first pass in one of the smaller/easier CSS files to get going and start thinking about how we want naming, etc. to be.

I expect that as we go, there will be a bunch of things added to the CSS variables first as more granular items, then we can look it over and find the values common across the variables and extract as it seems necessary.

One note -- I went ahead and made variables for `white` and `black`, since those are things that it's not too uncommon to specify as specific values later on.